### PR TITLE
Adding support for custom commands defined in simon.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -239,12 +239,12 @@ program.command('vagrant *')
 
 // Run a grunt command
 program.command('*')
-	.description('Run a given Grunt task')
+	.description('Run a task defined in simon.json')
 	.action(function (task) {
 		var args = parseArgs(task);
 		configureSimon(simon, config, program);
 		args.unshift(task);
-		simon.grunt.apply(simon, args);
+		simon.task.apply(simon, args);
 	});
 
 

--- a/lib/options/simon.json
+++ b/lib/options/simon.json
@@ -12,15 +12,18 @@
 			"composer",
 			"grunt",
 			"help",
-			"install",
 			"npm",
 			"permissions",
 			"php",
 			"phpunit",
-			"refresh",
-			"ssh",
-			"update"
-		]
+			"ssh"
+		],
+	},
+	"tasks": {
+		"start": [],
+		"install": [],
+		"refresh": [],
+		"update": []
 	},
 	"vagrant": {
 		"dir": "/vagrant"

--- a/lib/simon.js
+++ b/lib/simon.js
@@ -190,6 +190,13 @@ Simon.prototype = {
 	},
 
 	/**
+		Run the given task, as specified in simon.json
+	*/
+	task: function (name) {
+		// TODO: Write this
+	},
+
+	/**
 		Run a series of tasks consecutively. Tasks will not start running until
 		the previous task has completed. This method is asynchronous and will
 		return an event emitter. Here are the available events.
@@ -221,7 +228,6 @@ Simon.prototype = {
 					code > 0 ? 'with errors' : 'without errors'
 				));
 				emitter.currentTask = null;
-				//setImmediate(emitter.removeAllListeners.bind(emitter));
 			});
 
 			// Done event
@@ -259,8 +265,18 @@ Simon.prototype = {
 		if (tasks.length) {
 			try {
 				// Attempt to execute the task
-				task = this[tasks[0].name].apply(this, tasks[0].args);
+				var taskName = tasks[0].name;
+
+				// Make sure task name exists
+				if (!(taskName in this)) {
+					throw 'Invalid task "' + taskName +
+					'". Run `simon help` for a list of available tasks';
+				}
+
+				task = this[taskName].apply(this, tasks[0].args);
+
 			} catch (e) {
+
 				// Send an error function and return
 				setImmediate(function (emitter, task) {
 					emitter.emit('error', task, e);
@@ -631,7 +647,6 @@ Simon.prototype = {
 			message.error(e + '');
 			message.error('The site "' + url + '" could not be added.');
 			return false;
-
 		}
 
 		message.success('Added new site at ' + url.bold);


### PR DESCRIPTION
This way if we add any new dependencies or build steps, we can easily add them to `simon start`, or create custom commands like `simon refresh`.

To maintain backwards compatibility I'll add existing tasks as defaults to the base `simon.json`. It'll have one new field that looks like this:

``` json
{
    "tasks": {
        "start": [...],
        "install": [...],
        "refresh": [...],
        "update": [...]
    }
}
```

Each member of tasks will look something like like this

``` json
{
  "update": [{
    "command": "npm",
    "args": "update"
  }, {
    "command": "composer",
    "args": ["update"]
  }]
}
```

Where `command` is one of the available commands from `simon help`, and `args` is the array/string of parameters for that function.
